### PR TITLE
RCE fix

### DIFF
--- a/archivy/helpers.py
+++ b/archivy/helpers.py
@@ -14,7 +14,7 @@ def load_config(path=""):
     """Loads `config.yml` file and deserializes it to a python dict."""
     path = path or current_app.config["INTERNAL_DIR"]
     with (Path(path) / "config.yml").open() as f:
-        return yaml.load(f.read(), Loader=yaml.FullLoader)
+        return yaml.load(f.read(), Loader=yaml.SafeLoader)
 
 
 def write_config(config: dict):

--- a/archivy/helpers.py
+++ b/archivy/helpers.py
@@ -11,7 +11,7 @@ from archivy.config import BaseHooks
 
 
 def load_config(path=""):
-    """Loads `config.yml` file and deserializes it to a python dict."""
+    """Loads `config.yml` file safely and deserializes it to a python dict."""
     path = path or current_app.config["INTERNAL_DIR"]
     with (Path(path) / "config.yml").open() as f:
         return yaml.load(f.read(), Loader=yaml.SafeLoader)


### PR DESCRIPTION
### :bar_chart: Metadata *

Archivy is a self-hosted knowledge repository that allows you to safely preserve useful content that contributes to your knowledge bank.

#### Bounty URL: https://www.huntr.dev/bounties/1-pip-archivy

### :gear: Description *

Vulnerable to YAML deserialization attack caused by unsafe loading.

### :computer: Technical Description *

Fixed by avoiding unsafe loader.

### :bug: Proof of Concept (PoC) *

Create the following PoC file:
exploit.py

```
import os
#os.system('pip3 install archivy')
from archivy import helpers
exploit = """!!python/object/new:type
  args: ["z", !!python/tuple [], {"extend": !!python/name:exec }]
  listitems: "__import__('os').system('xcalc')"
"""
open('config.yml','w+').write(exploit)
helpers.load_config('.')

```

Execute the following commands in another terminal:

```
python3 exploit.py
```

    Check the Output:

xcalc will pop up.

### :fire: Proof of Fix (PoF) *

After fix it will not popup a calc.

### :+1: User Acceptance Testing (UAT)

After fix functionality is unaffected.
